### PR TITLE
Development fixes

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,19 +3,19 @@
 set -eu
 
 build=no
-if [ "${1-}" = 'build' ]; then
+if [ "${1-}" = "build" ]; then
   shift
   build=yes
 fi
 
 do_build() {
   printf "building...\r"
-  shards build > /dev/null
+  shards build -q
   printf "building...done\n"
 }
 
 crystal tool format
-ameba
+bin/ameba
 KEMAL_ENV=test crystal spec $@
 [ $build = yes ] && do_build
 echo All OK

--- a/scripts/setup-for-manual-testing.sh
+++ b/scripts/setup-for-manual-testing.sh
@@ -10,7 +10,7 @@ for arg in $@; do
 done
 
 make_admin() {
-  dppm server group add "name=admin's group" id=0 permissions='
+  bin/dppm server group add "name=admin's group" id=0 permissions='
       {
         "/**": {
           "permissions": [
@@ -19,7 +19,7 @@ make_admin() {
           "query_parameters": { }
         }
       }'
-  dppm server add_user name=admin groups=0
+  bin/dppm server add_user name=admin groups=0
 }
 
 DATA_DIR="${DATA_DIR:-"$PWD/data"}"
@@ -31,13 +31,13 @@ mkdir $DATA_DIR ||: nbd
 echo '{"groups":[], "users": []}' > $DATA_DIR/permissions.json
 
 shards build
-dppm server group add "name=${DPPM_USER}s group" id=$GROUP_ID
-dppm server add_user "name=$DPPM_USER" groups=$GROUP_ID
+bin/dppm server group add "name=${DPPM_USER}s group" id=$GROUP_ID
+bin/dppm server add_user "name=$DPPM_USER" groups=$GROUP_ID
 
 if [ $ADMIN = yes ]; then
   make_admin
 fi
 
-./bin/dppm server run
+bin/dppm server run
 
 rm -r data

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 1.0
 shards:
   ameba:
     github: veelenga/ameba
-    version: 0.9.1
+    version: 0.10.0
 
   clicr:
     github: j8r/clicr
@@ -22,7 +22,7 @@ shards:
 
   dppm:
     github: DFabric/dppm
-    commit: fb2cfce5793fd0e6a14e48d7d47441192ed577b0
+    commit: 76b0552b68dca73e0bb25e9fd8b6eb2e79985724
 
   dynany:
     github: j8r/dynany

--- a/shard.yml
+++ b/shard.yml
@@ -22,9 +22,9 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: ~> 0.9.1
+    version: ~> 0.10.0
 
 targets:
   dppm:
-    main: src/cli.cr
+    main: src/dppm_rest_api_cli.cr
     bootstrap-config: scripts/bootstrap-config.cr

--- a/src/actions/app.cr
+++ b/src/actions/app.cr
@@ -188,7 +188,6 @@ module DppmRestApi::Actions::App
       next context
     end
     deny_access! to: context
-    {% debug %}
   end
   # Delete the given application
   relative_delete "/:app_name" do |context|

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -4,7 +4,7 @@ require "./dppm_rest_api"
 module DppmRestApi::CLI
   extend self
 
-  # DPPM CLI isn't namespaced yet
+  macro run
   DPPM::CLI.run(
     server: {
       info:      "DPPM REST API server",
@@ -185,6 +185,7 @@ module DppmRestApi::CLI
       },
     }
   )
+  end
 
   # A helper method for the select_users method -- splits a comma-separated
   # list of numbers in a string into a `Set` of `Int32` values.

--- a/src/dppm_rest_api_cli.cr
+++ b/src/dppm_rest_api_cli.cr
@@ -1,0 +1,3 @@
+require "./cli"
+
+DppmRestApi::CLI.run

--- a/src/utils.cr
+++ b/src/utils.cr
@@ -18,7 +18,6 @@ macro fmt_route(route = "", namespace = false)
        .downcase
        .gsub(/^DppmRestApi::Actions::/, "")
        .gsub(/::/, "/") }} {% if namespace %} + "/:namespace" {% end %} + ( {{route}} || "")
-  {% debug %}
 end
 
 # the "last" or -1st block argument is selected because context is always the
@@ -29,7 +28,5 @@ macro relative_{{method.id}}(route, &block)
     namespace = \{{block.args[-1]}}.params.query["namespace"]? || DPPM::Prefix.default_group
     \{{block.body}}
   end
-  \{% debug %}
-  puts "built route at {{method.upcase.id}}:\t#{fmt_route(\{{route}})}"
 end
 {% end %}


### PR DESCRIPTION
Various fixes related to development, to avoid having the CLI and macro debug printed.
We may have a debug flag, if it's useful to you.

Two problems remains:
- running `crystal spec` hangs indefinitely. Ideally, it should work out of the box.
- a hash in `spec/permissions.json` changes, this is a bit annoying. It may be linked to the upper command, so adding to `.gitignore` isn't a proper solution.