### PR TITLE
Bug/route matching

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -42,7 +42,7 @@ shards:
 
   jwt:
     github: crystal-community/jwt
-    version: 0.4.0
+    version: 1.1.0
 
   kemal:
     github: kemalcr/kemal
@@ -63,6 +63,10 @@ shards:
   mysql:
     github: crystal-lang/crystal-mysql
     version: 0.6.0
+
+  openssl_ext:
+    github: stakach/openssl_ext
+    version: 1.0.0
 
   radix:
     github: luislavena/radix

--- a/shard.lock
+++ b/shard.lock
@@ -22,7 +22,7 @@ shards:
 
   dppm:
     github: DFabric/dppm
-    commit: 76b0552b68dca73e0bb25e9fd8b6eb2e79985724
+    commit: 4e0eac5b81274fbccd9ed3f94afc67f34fa13a4a
 
   dynany:
     github: j8r/dynany
@@ -50,7 +50,7 @@ shards:
 
   kemal_jwt_auth:
     github: dscottboggs/kemal-jwt-auth
-    version: 1.0.0
+    version: 1.0.1
 
   kilt:
     github: jeromegn/kilt

--- a/spec/actions/app_spec.cr
+++ b/spec/actions/app_spec.cr
@@ -3,27 +3,27 @@ require "../spec_helper"
 
 module DppmRestApi::Actions::App
   describe DppmRestApi::Actions::App do
-    describe (fmt_route "/:app_name/config/:key/get") do
+    describe (fmt_route "/:app_name/config/:key") do
       it "responds with 401 Unauthorized" do
-        get fmt_route "/some-app/config/key/get"
+        get fmt_route "/some-app/config/key"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name/config/:key/add") do
+    describe (fmt_route "/:app_name/config/:key") do
       it "responds with 401 Forbidden" do
-        post fmt_route "/some-app/config/key/add"
+        post fmt_route "/some-app/config/key"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name/config/:key/set") do
+    describe (fmt_route "/:app_name/config/:key") do
       it "responds with 401 Forbidden" do
-        put fmt_route "/some-app/config/key/set"
+        put fmt_route "/some-app/config/key"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name/config/:key/delete") do
+    describe (fmt_route "/:app_name/config/:key") do
       it "responds with 401 Forbidden" do
-        delete fmt_route "/some-app/config/key/delete"
+        delete fmt_route "/some-app/config/key"
         assert_unauthorized response
       end
     end
@@ -95,13 +95,13 @@ module DppmRestApi::Actions::App
     end
     describe (fmt_route "/:app_name/install") do
       it "responds with 401 Forbidden" do
-        put fmt_route "/some-pkg/install"
+        put fmt_route "/some-pkg"
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/remove") do
       it "responds with 401 Forbidden" do
-        delete fmt_route "/some-app/remove"
+        delete fmt_route "/some-app"
         assert_unauthorized response
       end
     end

--- a/spec/actions/app_spec.cr
+++ b/spec/actions/app_spec.cr
@@ -3,21 +3,27 @@ require "../spec_helper"
 
 module DppmRestApi::Actions::App
   describe DppmRestApi::Actions::App do
-    describe (fmt_route "/:app_name/config/:key") do
+    describe (fmt_route "/:app_name/config/:key/get") do
       it "responds with 401 Unauthorized" do
-        get fmt_route "/some-app/config/key"
+        get fmt_route "/some-app/config/key/get"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name/config/:key") do
+    describe (fmt_route "/:app_name/config/:key/add") do
       it "responds with 401 Forbidden" do
-        post fmt_route "/some-app/config/key"
+        post fmt_route "/some-app/config/key/add"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name/config/:keys") do
+    describe (fmt_route "/:app_name/config/:key/set") do
       it "responds with 401 Forbidden" do
-        delete fmt_route "/some-app/config/keys"
+        put fmt_route "/some-app/config/key/set"
+        assert_unauthorized response
+      end
+    end
+    describe (fmt_route "/:app_name/config/:key/delete") do
+      it "responds with 401 Forbidden" do
+        delete fmt_route "/some-app/config/key/delete"
         assert_unauthorized response
       end
     end
@@ -28,37 +34,37 @@ module DppmRestApi::Actions::App
       end
     end
     describe (fmt_route "/:app_name/service/boot") do
-      pending "responds with 401 Forbidden" do
+      it "responds with 401 Forbidden" do
         put (fmt_route "/some_app/service/boot")
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/service/reload") do
-      pending "responds with 401 Forbidden" do
+      it "responds with 401 Forbidden" do
         put (fmt_route "/some_app/service/reload")
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/service/restart") do
-      pending "responds with 401 Forbidden" do
+      it "responds with 401 Forbidden" do
         put (fmt_route "/some-app/service/restart")
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/service/start") do
-      pending "responds with 401 Forbidden" do
+      it "responds with 401 Forbidden" do
         put (fmt_route "/some-app/service/start")
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/service/status") do
-      pending "responds with 401 Forbidden" do
-        put (fmt_route "/some-app/service/status")
+      it "responds with 401 Forbidden" do
+        get fmt_route "/some-app/service/status"
         assert_unauthorized response
       end
     end
     describe (fmt_route "/:app_name/service/stop") do
-      pending "responds with 401 Forbidden" do
+      it "responds with 401 Forbidden" do
         put (fmt_route "/some-app/service/stop")
         assert_unauthorized response
       end
@@ -87,18 +93,15 @@ module DppmRestApi::Actions::App
         assert_unauthorized response
       end
     end
-    pending "ws #{fmt_route "/:app_name/logs"}" do
-      # spec-kemal has no way to test websocket routes
-    end
-    describe (fmt_route "/:package_name") do
-      pending "responds with 401 Forbidden" do
-        put fmt_route "/some-pkg"
+    describe (fmt_route "/:app_name/install") do
+      it "responds with 401 Forbidden" do
+        put fmt_route "/some-pkg/install"
         assert_unauthorized response
       end
     end
-    describe (fmt_route "/:app_name") do
+    describe (fmt_route "/:app_name/remove") do
       it "responds with 401 Forbidden" do
-        delete fmt_route "/some-app/"
+        delete fmt_route "/some-app/remove"
         assert_unauthorized response
       end
     end

--- a/spec/actions/pkg_spec.cr
+++ b/spec/actions/pkg_spec.cr
@@ -3,40 +3,35 @@ require "../spec_helper"
 
 module DppmRestApi::Actions::Pkg
   describe DppmRestApi::Actions::Pkg do
-    describe "get ALL_PKGS" do
+    describe "get all package config" do
       it "responds with 401 Forbidden" do
-        get fmt_route ALL_PKGS
+        get fmt_route nil
         assert_unauthorized response
       end
     end
-    describe "delete ALL_PKGS" do
+    describe "clear unused packages (#{fmt_route "/clean"})" do
       it "responds with 401 Forbidden" do
-        delete fmt_route ALL_PKGS
+        delete fmt_route "/clean"
         assert_unauthorized response
       end
     end
-    describe "get ONE_PKG" do
+    describe "get /:id/query" do
       it "responds with 401 Forbidden" do
-        get fmt_route ONE_PKG
+        get fmt_route "/package-id/query"
         assert_unauthorized response
       end
     end
-    describe "delete ONE_PKG" do
+    describe "delete a package (/:id/delete)" do
       it "responds with 401 Forbidden" do
-        delete fmt_route ONE_PKG
+        delete fmt_route "/package-id/delete"
         assert_unauthorized response
       end
     end
   end
-
-  module Build
-    describe Build do
-      describe "post fmt_route \"/:package\"" do
-        it "responds with 401 Forbidden" do
-          post fmt_route "/some-package"
-          response.status_code.should eq 401
-        end
-      end
+  describe "post fmt_route \"/:id/build\"" do
+    it "responds with 401 Forbidden" do
+      post fmt_route "/some-package/build"
+      assert_unauthorized response
     end
   end
 end

--- a/spec/actions/service_spec.cr
+++ b/spec/actions/service_spec.cr
@@ -40,8 +40,8 @@ module DppmRestApi::Actions::Service
       end
     end
     describe (fmt_route "/:service/status") do
-      pending "responds with 401 Forbidden" do
-        put (fmt_route "/some-service/status")
+      it "responds with 401 Forbidden" do
+        get (fmt_route "/some-service/status")
         assert_unauthorized response
       end
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,9 @@ def new_test_context(verb = "GET", path = "/api/test")
   {backing_io, HTTP::Server::Context.new(request, response)}
 end
 
-def assert_unauthorized(response : HTTP::Client::Response)
+# The only reason this is a macro is that a macro shows the location where it
+# is expanded on failure, a def shows the location of the def.
+macro assert_unauthorized(response)
   response.status_code.should eq 401
   found = ErrorResponse.from_json(response.body)
     .errors

--- a/src/actions.cr
+++ b/src/actions.cr
@@ -36,8 +36,4 @@ module DppmRestApi::Actions
       IO.copy file, context.response
     end
   end
-
-  def self.deny_access!(to context)
-    raise Unauthorized.new context
-  end
 end

--- a/src/actions/app.cr
+++ b/src/actions/app.cr
@@ -51,32 +51,25 @@ module DppmRestApi::Actions::App
     end
     raise Unauthorized.new context
   end
-  relative_post "/:app_name/config/:key/add" do |context|
+  relative_post "/:app_name/config/:key" do |context|
     if context.current_user? && Config.has_access? context, Access::Create
       set_config context, context.params.url["key"], context.params.url["app_name"]
       next context
     end
     raise Unauthorized.new context
   end
-  relative_put "/:app_name/config/:key/set" do |context|
+  relative_put "/:app_name/config/:key" do |context|
     if context.current_user? && Config.has_access? context, Access::Update
       set_config context, context.params.url["key"], context.params.url["app_name"]
       next context
     end
     raise Unauthorized.new context
   end
-  relative_delete "/:app_name/config/:key/delete" do |context|
+  relative_delete "/:app_name/config/:key" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       DPPM::Prefix.new(prefix)
         .new_app(context.params.url["app_name"])
         .del_config context.params.url["key"]
-      next context
-    end
-    raise Unauthorized.new context
-  end
-  relative_get "/:app_name/config/:key/get" do |context|
-    if context.current_user? && Config.has_access? context, Access::Delete
-      # TODO
       next context
     end
     raise Unauthorized.new context
@@ -174,7 +167,7 @@ module DppmRestApi::Actions::App
     raise Unauthorized.new context
   end
   # Install the given package
-  relative_put "/:app_name/install" do |context|
+  relative_put "/:app_name" do |context|
     if context.current_user? && Config.has_access? context, Access::Create
       # TODO: install the package and return its name
       next context
@@ -182,7 +175,7 @@ module DppmRestApi::Actions::App
     raise Unauthorized.new context
   end
   # Delete the given application
-  relative_delete "/:app_name/remove" do |context|
+  relative_delete "/:app_name" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       # TODO: delete the app
       next context

--- a/src/actions/app.cr
+++ b/src/actions/app.cr
@@ -51,25 +51,32 @@ module DppmRestApi::Actions::App
     end
     raise Unauthorized.new context
   end
-  relative_post "/:app_name/config/:key" do |context|
+  relative_post "/:app_name/config/:key/add" do |context|
     if context.current_user? && Config.has_access? context, Access::Create
       set_config context, context.params.url["key"], context.params.url["app_name"]
       next context
     end
     raise Unauthorized.new context
   end
-  relative_put "/:app_name/config/:key" do |context|
+  relative_put "/:app_name/config/:key/set" do |context|
     if context.current_user? && Config.has_access? context, Access::Update
       set_config context, context.params.url["key"], context.params.url["app_name"]
       next context
     end
     raise Unauthorized.new context
   end
-  relative_delete "/:app_name/config/:key" do |context|
+  relative_delete "/:app_name/config/:key/delete" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       DPPM::Prefix.new(prefix)
         .new_app(context.params.url["app_name"])
         .del_config context.params.url["key"]
+      next context
+    end
+    raise Unauthorized.new context
+  end
+  relative_get "/:app_name/config/:key/get" do |context|
+    if context.current_user? && Config.has_access? context, Access::Delete
+      # TODO
       next context
     end
     raise Unauthorized.new context
@@ -116,8 +123,8 @@ module DppmRestApi::Actions::App
     end
     raise Unauthorized.new context
   end
-  # relative_get the status of the service associated with the given application
-  relative_put "/:app_name/service/status" do |context|
+  # get the status of the service associated with the given application
+  relative_get "/:app_name/service/status" do |context|
     if context.current_user? && Config.has_access? context, Access::Read
       # TODO: get the status of the service
       next context
@@ -166,17 +173,8 @@ module DppmRestApi::Actions::App
     end
     raise Unauthorized.new context
   end
-  # Stream the logs for the given application over the websocket connection.
-  relative_ws "/:app_name/logs" do |_, context|
-    # The first block argument is the open socket to the browser.
-    if context.current_user? && Config.has_access? context, Access::Read
-      # TODO: stream logs to sock
-      next context
-    end
-    raise Unauthorized.new context
-  end
   # Install the given package
-  relative_put "/:package_name" do |context|
+  relative_put "/:app_name/install" do |context|
     if context.current_user? && Config.has_access? context, Access::Create
       # TODO: install the package and return its name
       next context
@@ -184,7 +182,7 @@ module DppmRestApi::Actions::App
     raise Unauthorized.new context
   end
   # Delete the given application
-  relative_delete "/:app_name" do |context|
+  relative_delete "/:app_name/remove" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       # TODO: delete the app
       next context

--- a/src/actions/pkg.cr
+++ b/src/actions/pkg.cr
@@ -1,9 +1,7 @@
 module DppmRestApi::Actions::Pkg
   extend self
-  ALL_PKGS = ""
-  ONE_PKG  = "/:id"
   # List built packages
-  relative_get ALL_PKGS do |context|
+  relative_get nil do |context|
     if context.current_user? && Config.has_access? context, Access::Read
       # TODO: list all built packages
       next context
@@ -11,7 +9,7 @@ module DppmRestApi::Actions::Pkg
     raise Unauthorized.new context
   end
   # Clean unused built packages
-  relative_delete ALL_PKGS do |context|
+  relative_delete "/clean" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       # TODO: delete all unused built packages
       next context
@@ -19,7 +17,7 @@ module DppmRestApi::Actions::Pkg
     raise Unauthorized.new context
   end
   # Query information about a given package
-  relative_get ONE_PKG do |context|
+  relative_get "/:id/query" do |context|
     if context.current_user? && Config.has_access? context, Access::Read
       # TODO: Query information about the given package
       next context
@@ -27,24 +25,21 @@ module DppmRestApi::Actions::Pkg
     raise Unauthorized.new context
   end
   # Delete a given package
-  relative_delete ONE_PKG do |context|
+  relative_delete "/:id/delete" do |context|
     if context.current_user? && Config.has_access? context, Access::Delete
       # TODO: Query information about the given package
       next context
     end
     raise Unauthorized.new context
   end
-
-  module Build
-    # Build a package, returning the ID of the built image, and perhaps a status
-    # message? We could also use server-side events or a websocket to provide the
-    # status of this action as it occurs over the API, rather than just returning
-    # a result on completion.
-    relative_post "/:package" do |context|
-      if context.current_user? && Config.has_access? context, Access::Create
-        # TODO: build the package based on the submitted configuration
-      end
-      raise Unauthorized.new context
+  # Build a package, returning the ID of the built image, and perhaps a status
+  # message? We could also use server-side events or a websocket to provide the
+  # status of this action as it occurs over the API, rather than just returning
+  # a result on completion.
+  relative_post "/:id/build" do |context|
+    if context.current_user? && Config.has_access? context, Access::Create
+      # TODO: build the package based on the submitted configuration
     end
+    raise Unauthorized.new context
   end
 end


### PR DESCRIPTION
~> `Duplicate trail found 'get/dppmrestapi/actions/app/:app_name/config/:key' (Radix::Tree::DuplicateError)`~

~We can't use this route for multiple endpoints. We can use `/app/:app_name/config/:key/{get,set,etc...}` or `/app/:app_name/config-{get,set,etc...}/:key`, but we can't use the same route multiple times with different verbs in Kemal. This is a limitation of using the Radix tree, and was why @Blacksmoke16 elected to not use a Radix tree for route matching in Athena.~

~Other than that hiccup,~ this PR resolves all routing issues and makes all formerly `pending` specs pass. :tada: :grin: 