### PR TITLE
Add user/me tests

### DIFF
--- a/src/actions/user.cr
+++ b/src/actions/user.cr
@@ -76,9 +76,15 @@ module DppmRestApi
       raise Unauthorized.new context unless Actions.has_access? context, Access::Read
       if me = Config::User.from_h context.current_user
         build_json context.response do |response|
-          me.to_json response, except: :api_key_hash
+          response.field "currentUser" do
+            me.to_json response, except: :api_key_hash
+          end
         end
       else
+        log "\
+          Reaching this branch is genuinely a bug, probably in the generation \
+          of the JWT, perhaps in the kemal-jwt-auth external shard. See the \
+          logged exception."
         raise InternalServerError.new context, "Parsing of #{context.current_user} failed!"
       end
       context.response.flush

--- a/src/config/user.cr
+++ b/src/config/user.cr
@@ -16,7 +16,7 @@ struct DppmRestApi::Config::User
   end
 
   def self.new(api_key_hash string : String,
-               groups : Set(Int32),
+               groups : Enumerable(Int32),
                name : String,
                id : UUID)
     new Scrypt::Password.new(string), groups.to_set, name, id
@@ -82,7 +82,7 @@ struct DppmRestApi::Config::User
     builder.object do
       {% for ivar in @type.instance_vars %}
         unless except.includes? {{ivar.name.symbolize}}
-          builder.field({{ivar.name.stringify}}) { {{ivar}}.to_json builder }
+          builder.field({{ivar.name.stringify}}) { @{{ivar}}.to_json builder }
         end
       {% end %}
     end


### PR DESCRIPTION
This PR adds a spec for the `GET /dppmrestapi/user/me` route, and some refactoring and revisions as a result of the testing.